### PR TITLE
refactor: merge `BoolLit` and `NatLit` type into `Literal` type

### DIFF
--- a/compiler-testsuite/crates/compiler-test/snapshots/lexer/output/snap@example_1.snap
+++ b/compiler-testsuite/crates/compiler-test/snapshots/lexer/output/snap@example_1.snap
@@ -53,7 +53,7 @@ expression: token
     },
     Token {
         lexeme: "T",
-        ty: BoolLit,
+        ty: Literal,
         span: Span {
             start: 43,
             end: 43,
@@ -85,7 +85,7 @@ expression: token
     },
     Token {
         lexeme: "1",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 51,
             end: 51,
@@ -101,7 +101,7 @@ expression: token
     },
     Token {
         lexeme: "0",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 55,
             end: 55,
@@ -117,7 +117,7 @@ expression: token
     },
     Token {
         lexeme: "T",
-        ty: BoolLit,
+        ty: Literal,
         span: Span {
             start: 58,
             end: 58,
@@ -149,7 +149,7 @@ expression: token
     },
     Token {
         lexeme: "0",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 67,
             end: 67,
@@ -173,7 +173,7 @@ expression: token
     },
     Token {
         lexeme: "2",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 72,
             end: 72,
@@ -189,7 +189,7 @@ expression: token
     },
     Token {
         lexeme: "0",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 76,
             end: 76,
@@ -205,7 +205,7 @@ expression: token
     },
     Token {
         lexeme: "1",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 80,
             end: 80,

--- a/compiler-testsuite/crates/compiler-test/snapshots/lexer/output/snap@example_1_compact.snap
+++ b/compiler-testsuite/crates/compiler-test/snapshots/lexer/output/snap@example_1_compact.snap
@@ -45,7 +45,7 @@ expression: token
     },
     Token {
         lexeme: "T",
-        ty: BoolLit,
+        ty: Literal,
         span: Span {
             start: 15,
             end: 15,
@@ -77,7 +77,7 @@ expression: token
     },
     Token {
         lexeme: "1",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 19,
             end: 19,
@@ -93,7 +93,7 @@ expression: token
     },
     Token {
         lexeme: "0",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 21,
             end: 21,
@@ -109,7 +109,7 @@ expression: token
     },
     Token {
         lexeme: "T",
-        ty: BoolLit,
+        ty: Literal,
         span: Span {
             start: 24,
             end: 24,
@@ -141,7 +141,7 @@ expression: token
     },
     Token {
         lexeme: "0",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 31,
             end: 31,
@@ -165,7 +165,7 @@ expression: token
     },
     Token {
         lexeme: "2",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 34,
             end: 34,
@@ -181,7 +181,7 @@ expression: token
     },
     Token {
         lexeme: "0",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 36,
             end: 36,
@@ -197,7 +197,7 @@ expression: token
     },
     Token {
         lexeme: "1",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 38,
             end: 38,

--- a/compiler-testsuite/crates/compiler-test/snapshots/lexer/output/snap@example_2.snap
+++ b/compiler-testsuite/crates/compiler-test/snapshots/lexer/output/snap@example_2.snap
@@ -61,7 +61,7 @@ expression: token
     },
     Token {
         lexeme: "T",
-        ty: BoolLit,
+        ty: Literal,
         span: Span {
             start: 24,
             end: 24,
@@ -109,7 +109,7 @@ expression: token
     },
     Token {
         lexeme: "0",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 36,
             end: 36,
@@ -125,7 +125,7 @@ expression: token
     },
     Token {
         lexeme: "T",
-        ty: BoolLit,
+        ty: Literal,
         span: Span {
             start: 39,
             end: 39,
@@ -157,7 +157,7 @@ expression: token
     },
     Token {
         lexeme: "1",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 49,
             end: 49,
@@ -165,7 +165,7 @@ expression: token
     },
     Token {
         lexeme: "4",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 51,
             end: 51,
@@ -181,7 +181,7 @@ expression: token
     },
     Token {
         lexeme: "2",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 53,
             end: 53,
@@ -205,7 +205,7 @@ expression: token
     },
     Token {
         lexeme: "0",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 58,
             end: 58,

--- a/compiler-testsuite/crates/compiler-test/snapshots/lexer/output/snap@example_3.snap
+++ b/compiler-testsuite/crates/compiler-test/snapshots/lexer/output/snap@example_3.snap
@@ -93,7 +93,7 @@ expression: token
     },
     Token {
         lexeme: "0",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 35,
             end: 35,
@@ -141,7 +141,7 @@ expression: token
     },
     Token {
         lexeme: "0",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 47,
             end: 47,
@@ -157,7 +157,7 @@ expression: token
     },
     Token {
         lexeme: "0",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 52,
             end: 52,
@@ -277,7 +277,7 @@ expression: token
     },
     Token {
         lexeme: "1",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 83,
             end: 83,
@@ -301,7 +301,7 @@ expression: token
     },
     Token {
         lexeme: "1",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 87,
             end: 87,
@@ -365,7 +365,7 @@ expression: token
     },
     Token {
         lexeme: "T",
-        ty: BoolLit,
+        ty: Literal,
         span: Span {
             start: 110,
             end: 110,
@@ -405,7 +405,7 @@ expression: token
     },
     Token {
         lexeme: "1",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 122,
             end: 122,
@@ -413,7 +413,7 @@ expression: token
     },
     Token {
         lexeme: "0",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 124,
             end: 124,
@@ -437,7 +437,7 @@ expression: token
     },
     Token {
         lexeme: "0",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 129,
             end: 129,
@@ -453,7 +453,7 @@ expression: token
     },
     Token {
         lexeme: "T",
-        ty: BoolLit,
+        ty: Literal,
         span: Span {
             start: 132,
             end: 132,
@@ -485,7 +485,7 @@ expression: token
     },
     Token {
         lexeme: "2",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 142,
             end: 142,
@@ -509,7 +509,7 @@ expression: token
     },
     Token {
         lexeme: "0",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 147,
             end: 147,

--- a/compiler-testsuite/crates/compiler-test/snapshots/lexer/output/snap@example_4.snap
+++ b/compiler-testsuite/crates/compiler-test/snapshots/lexer/output/snap@example_4.snap
@@ -29,7 +29,7 @@ expression: token
     },
     Token {
         lexeme: "1",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 10,
             end: 10,
@@ -85,7 +85,7 @@ expression: token
     },
     Token {
         lexeme: "T",
-        ty: BoolLit,
+        ty: Literal,
         span: Span {
             start: 29,
             end: 29,
@@ -117,7 +117,7 @@ expression: token
     },
     Token {
         lexeme: "1",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 37,
             end: 37,
@@ -133,7 +133,7 @@ expression: token
     },
     Token {
         lexeme: "0",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 41,
             end: 41,
@@ -189,7 +189,7 @@ expression: token
     },
     Token {
         lexeme: "T",
-        ty: BoolLit,
+        ty: Literal,
         span: Span {
             start: 61,
             end: 61,
@@ -221,7 +221,7 @@ expression: token
     },
     Token {
         lexeme: "F",
-        ty: BoolLit,
+        ty: Literal,
         span: Span {
             start: 69,
             end: 69,
@@ -237,7 +237,7 @@ expression: token
     },
     Token {
         lexeme: "0",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 73,
             end: 73,
@@ -253,7 +253,7 @@ expression: token
     },
     Token {
         lexeme: "1",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 76,
             end: 76,
@@ -277,7 +277,7 @@ expression: token
     },
     Token {
         lexeme: "2",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 83,
             end: 83,
@@ -293,7 +293,7 @@ expression: token
     },
     Token {
         lexeme: "1",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 87,
             end: 87,

--- a/compiler-testsuite/crates/compiler-test/snapshots/lexer/output/snap@example_5.snap
+++ b/compiler-testsuite/crates/compiler-test/snapshots/lexer/output/snap@example_5.snap
@@ -21,7 +21,7 @@ expression: token
     },
     Token {
         lexeme: "2",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 9,
             end: 9,
@@ -37,7 +37,7 @@ expression: token
     },
     Token {
         lexeme: "1",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 14,
             end: 14,
@@ -53,7 +53,7 @@ expression: token
     },
     Token {
         lexeme: "4",
-        ty: NatLit,
+        ty: Literal,
         span: Span {
             start: 27,
             end: 27,

--- a/compiler-testsuite/crates/mini-compiler-rs/src/token.rs
+++ b/compiler-testsuite/crates/mini-compiler-rs/src/token.rs
@@ -47,8 +47,7 @@ impl From<*mut gen::Span> for Span {
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum TokenTy {
-    BoolLit,      /* Boolean Literal */
-    NatLit,       /* Natural Number Literal */
+    Literal,      /* Literal */
     BoolDecl,     /* The variable type Boolean */
     NatDecl,      /* The variable type Natural */
     FuncDecl,     /* The variable type Function */
@@ -71,8 +70,7 @@ pub enum TokenTy {
 impl From<gen::TokenTy> for TokenTy {
     fn from(value: gen::TokenTy) -> Self {
         match value {
-            gen::TokenTy_BoolLit => TokenTy::BoolLit,
-            gen::TokenTy_NatLit => TokenTy::NatLit,
+            gen::TokenTy_Literal => TokenTy::Literal,
             gen::TokenTy_BoolDecl => TokenTy::BoolDecl,
             gen::TokenTy_NatDecl => TokenTy::NatDecl,
             gen::TokenTy_FuncDecl => TokenTy::FuncDecl,

--- a/lexer.c
+++ b/lexer.c
@@ -62,11 +62,8 @@ Token *eof_token() {
 
 int debug_token(Token *token, char *buf, size_t bufsz) {
     switch (token->ty) {
-        case BoolLit: /* Boolean Literal */
-            return snprintf(buf, bufsz, "BoolLit(%s)", token->lexeme);
-
-        case NatLit: /* Natural Number Literal */
-            return snprintf(buf, bufsz, "NatLit(%s)", token->lexeme);
+        case Literal: /* Boolean Literal */
+            return snprintf(buf, bufsz, "Literal(%s)", token->lexeme);
 
         case BoolDecl: /* The variable type Boolean */
             return snprintf(buf, bufsz, "BoolDecl");
@@ -166,7 +163,7 @@ TokenTy get_token_type(char *lexeme) {
     }
 
     if (strcmp(lexeme, "T") == 0 || strcmp(lexeme, "F") == 0) {
-        return BoolLit;
+        return Literal;
     }
 
     if (strcmp(lexeme, "bool") == 0) {
@@ -178,7 +175,7 @@ TokenTy get_token_type(char *lexeme) {
     }
 
     if (isdigit(lexeme[0])) {
-        return NatLit;
+        return Literal;
     } else {
         return Identifier;
     }

--- a/lexer.h
+++ b/lexer.h
@@ -13,8 +13,7 @@ Span *span_new(unsigned start, unsigned end);
 void destroy_span(Span *span);
 
 typedef enum TokenTy {
-    BoolLit,      /* Boolean Literal */
-    NatLit,       /* Natural Number Literal */
+    Literal,      /* Boolean or Natural Literal */
     BoolDecl,     /* The variable type Boolean */
     NatDecl,      /* The variable type Natural */
     FuncDecl,     /* The variable type Function */

--- a/parser.c
+++ b/parser.c
@@ -181,7 +181,7 @@ SLRop shift_reduce_table_get(const SLRop (*shift_reduce_table)[16],
         case RightParen:
             symbol_idx = 9;
             break;
-        case NatLit:
+        case Literal:
             symbol_idx = 10;
             break;
         case Plus:

--- a/parser.h
+++ b/parser.h
@@ -145,7 +145,7 @@ static const Production P12 = {.n_rhs = 1,
 static const Production P13 = {.n_rhs = 3,
                                .lhs = {.value = {'E'}, .ty = TERM_NON_TERMINAL},
                                .rhs = {
-                                   {.value = {NatLit}, .ty = TERM_TERMINAL},
+                                   {.value = {Literal}, .ty = TERM_TERMINAL},
                                    {.value = {Plus}, .ty = TERM_TERMINAL},
                                    {.value = {'E'}, .ty = TERM_NON_TERMINAL},
                                }};
@@ -154,7 +154,7 @@ static const Production P13 = {.n_rhs = 3,
 static const Production P14 = {.n_rhs = 1,
                                .lhs = {.value = {'E'}, .ty = TERM_NON_TERMINAL},
                                .rhs = {
-                                   {.value = {NatLit}, .ty = TERM_TERMINAL},
+                                   {.value = {Literal}, .ty = TERM_TERMINAL},
                                }};
 
 // B -> E R E & B


### PR DESCRIPTION
Make the code consistent with context free grammar